### PR TITLE
Add Google Authentication with Passport.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,7 +1,30 @@
 import express from 'express';
+import passport from 'passport';
+import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 
 const app = express();
 const port = 3000;
+
+passport.use(new GoogleStrategy({
+  clientID: 'YOUR_GOOGLE_CLIENT_ID',
+  clientSecret: 'YOUR_GOOGLE_CLIENT_SECRET',
+  callbackURL: 'http://localhost:3000/auth/google/callback'
+}, (accessToken, refreshToken, profile, done) => {
+  // Here you would find or create a user in your database
+  return done(null, profile);
+}));
+
+app.use(passport.initialize());
+
+app.get('/auth/google', passport.authenticate('google', {
+  scope: ['https://www.googleapis.com/auth/plus.login']
+}));
+
+app.get('/auth/google/callback', passport.authenticate('google', {
+  failureRedirect: '/login'
+}), (req, res) => {
+  res.redirect('/');
+});
 
 app.get('/hello', (req, res) => {
   res.send('hello');


### PR DESCRIPTION
## Summary

This PR integrates Google authentication into the existing Express server using Passport.js. It adds the necessary routes for Google OAuth login and callback, and configures Passport middleware.

## Changes
- Added Passport.js and Google OAuth strategy.
- Configured routes for `/auth/google` and `/auth/google/callback`.
- Initialized Passport middleware in `server.js`.

## Instructions
- Replace `YOUR_GOOGLE_CLIENT_ID` and `YOUR_GOOGLE_CLIENT_SECRET` with actual credentials.

## Test Results

✅ Code changes have been reviewed and are ready for testing.

Output:
```
No tests executed as per request.
```